### PR TITLE
raise_error_if_model_undefined

### DIFF
--- a/clarifai/rest/client.py
+++ b/clarifai/rest/client.py
@@ -1322,6 +1322,10 @@ class Models(object):
 
         model = res[0]
         self.model_id_cache.update({(model_name, model_type): model.model_id})
+      else:
+        logging.error('Error in clarifai get model. Status code: {}, error code: {}'
+                      .format(e.response.status_code, e.error_code))
+        raise e
 
     return model
 


### PR DESCRIPTION
prevent error from being raised due to model not being defined.

can raise api error as backend_server handles it.