### PR TITLE
[COL-8590] update image search endpoint

### DIFF
--- a/clarifai/rest/client.py
+++ b/clarifai/rest/client.py
@@ -3580,7 +3580,7 @@ class ApiClient(object):
       scores
     """
 
-    resource = "inputs/searches/"
+    resource = "users/aspire/apps/7277eb7cb3f54adfa8c923f1765eca4b/inputs/searches/"
 
     # Similar image search and predictions
     d = {'pagination': pagination(page, per_page).dict(),

--- a/clarifai/rest/client.py
+++ b/clarifai/rest/client.py
@@ -3582,7 +3582,14 @@ class ApiClient(object):
 
     resource = "users/aspire/apps/7277eb7cb3f54adfa8c923f1765eca4b/inputs/searches/"
     print("query shape %s" % query['ands'])
-    image_url = query['ands'][1]['output']['input']['data']['image']['url']
+    image_url = None
+    metadata = None
+    if (len(query['ands']) == 1):
+      image_url = query['ands'][0]['output']['input']['data']['image']['url']
+    else:
+      metadata = query['ands'][0]['input']['data']['metadata']
+      image_url = query['ands'][1]['output']['input']['data']['image']['url']
+
     searches = [{
       'query': {
         'ranks': [{

--- a/clarifai/rest/client.py
+++ b/clarifai/rest/client.py
@@ -3581,7 +3581,7 @@ class ApiClient(object):
     """
 
     resource = "users/aspire/apps/7277eb7cb3f54adfa8c923f1765eca4b/inputs/searches/"
-
+    print("query shape %s" % query)
     # Similar image search and predictions
     d = {'pagination': pagination(page, per_page).dict(),
          'query': query

--- a/clarifai/rest/client.py
+++ b/clarifai/rest/client.py
@@ -3581,11 +3581,18 @@ class ApiClient(object):
     """
 
     resource = "users/aspire/apps/%s/inputs/searches/" % CLARIFAI_APP_ID
-    metadata = {}
+    filters = []
     if (len(query['ands']) == 1):
       image = query['ands'][0]['output']['input']['data']['image']
     else:
       metadata = query['ands'][0]['input']['data']['metadata']
+      filters = [{
+        "annotation": {
+          "data": {
+            "metadata": metadata
+          }
+        }
+      }]
       image = query['ands'][1]['output']['input']['data']['image']
 
     searches = [{
@@ -3594,10 +3601,10 @@ class ApiClient(object):
           'annotation': {
             "data": {
               "image": image,
-              "metadata": metadata
             }
           }
-        }]
+        }],
+        "filters": filters
       }
     }]
 

--- a/clarifai/rest/client.py
+++ b/clarifai/rest/client.py
@@ -39,7 +39,7 @@ PYTHON_VERSION = '.'.join(map(str, [os.sys.version_info.major, os.sys.version_in
 GITHUB_TAG_ENDPOINT = 'https://api.github.com/repos/clarifai/clarifai-python/git/refs/tags'
 
 DEFAULT_TAG_MODEL = 'general-v1.3'
-
+CLARIFAI_APP_ID = '7277eb7cb3f54adfa8c923f1765eca4b'
 
 class ClarifaiApp(object):
   """ Clarifai Application Object
@@ -3580,10 +3580,8 @@ class ApiClient(object):
       scores
     """
 
-    resource = "users/aspire/apps/7277eb7cb3f54adfa8c923f1765eca4b/inputs/searches/"
-    print("query shape %s" % query['ands'])
-    image_url = None
-    metadata = None
+    resource = "users/aspire/apps/%s/inputs/searches/" % CLARIFAI_APP_ID
+    metadata = {}
     if (len(query['ands']) == 1):
       image = query['ands'][0]['output']['input']['data']['image']
     else:
@@ -3595,7 +3593,8 @@ class ApiClient(object):
         'ranks': [{
           'annotation': {
             "data": {
-              "image": image
+              "image": image,
+              "metadata": metadata
             }
           }
         }]

--- a/clarifai/rest/client.py
+++ b/clarifai/rest/client.py
@@ -3581,7 +3581,7 @@ class ApiClient(object):
     """
 
     resource = "users/aspire/apps/7277eb7cb3f54adfa8c923f1765eca4b/inputs/searches/"
-    print("query shape %s" % query)
+    print("query shape %s" % query['ands'])
     image_url = query['ands'][1]['output']['input']['data']['image']['url']
     searches = [{
       'query': {

--- a/clarifai/rest/client.py
+++ b/clarifai/rest/client.py
@@ -3583,11 +3583,10 @@ class ApiClient(object):
     # clarifai new image search endpoint
     resource = "users/aspire/apps/%s/inputs/searches/" % CLARIFAI_APP_ID
 
-    # extract old query request values
     filters = []
     image = None
-
     try:
+      # extract old query request values
       if (len(query['ands']) == 2):
         metadata = query['ands'][0]['input']['data']['metadata']
         filters = [{

--- a/clarifai/rest/client.py
+++ b/clarifai/rest/client.py
@@ -3580,7 +3580,10 @@ class ApiClient(object):
       scores
     """
 
+    # clarifai new image search endpoint
     resource = "users/aspire/apps/%s/inputs/searches/" % CLARIFAI_APP_ID
+
+    # extract old query request values
     filters = []
     if (len(query['ands']) == 2):
       metadata = query['ands'][0]['input']['data']['metadata']
@@ -3595,6 +3598,7 @@ class ApiClient(object):
     else:
       image = query['ands'][0]['output']['input']['data']['image']
 
+    # the new endpoint expects this shape of the request data object
     searches = [{
       'query': {
         'ranks': [{

--- a/clarifai/rest/client.py
+++ b/clarifai/rest/client.py
@@ -3582,9 +3582,22 @@ class ApiClient(object):
 
     resource = "users/aspire/apps/7277eb7cb3f54adfa8c923f1765eca4b/inputs/searches/"
     print("query shape %s" % query)
+    image_url = query['ands'][1]['output']['input']['data']['image']['url']
+    searches = [{
+      'query': {
+        'ranks': [{
+          'annotation': {
+            "data": {
+              "image": image_url
+            }
+          }
+        }]
+      }
+    }]
+
     # Similar image search and predictions
     d = {'pagination': pagination(page, per_page).dict(),
-         'query': query
+         'searches': searches
          }
 
     res = self.post(resource, d)

--- a/clarifai/rest/client.py
+++ b/clarifai/rest/client.py
@@ -3579,7 +3579,7 @@ class ApiClient(object):
       raw JSON response from the API server, with a list of inputs and corresponding ranking
       scores
     """
-
+    print('raw query %s' % query)
     resource = "users/aspire/apps/%s/inputs/searches/" % CLARIFAI_APP_ID
     filters = []
     if (len(query['ands']) == 2):

--- a/clarifai/rest/client.py
+++ b/clarifai/rest/client.py
@@ -3580,7 +3580,7 @@ class ApiClient(object):
       scores
     """
 
-    resource = "searches/"
+    resource = "inputs/searches/"
 
     # Similar image search and predictions
     d = {'pagination': pagination(page, per_page).dict(),

--- a/clarifai/rest/client.py
+++ b/clarifai/rest/client.py
@@ -3579,7 +3579,7 @@ class ApiClient(object):
       raw JSON response from the API server, with a list of inputs and corresponding ranking
       scores
     """
-    print('raw query %s' % query)
+
     resource = "users/aspire/apps/%s/inputs/searches/" % CLARIFAI_APP_ID
     filters = []
     if (len(query['ands']) == 2):
@@ -3607,8 +3607,6 @@ class ApiClient(object):
         "filters": filters
       }
     }]
-
-    print('searches %s' % searches)
 
     # Similar image search and predictions
     d = {'pagination': pagination(page, per_page).dict(),

--- a/clarifai/rest/client.py
+++ b/clarifai/rest/client.py
@@ -3582,9 +3582,7 @@ class ApiClient(object):
 
     resource = "users/aspire/apps/%s/inputs/searches/" % CLARIFAI_APP_ID
     filters = []
-    if (len(query['ands']) == 1):
-      image = query['ands'][0]['output']['input']['data']['image']
-    else:
+    if (len(query['ands']) == 2):
       metadata = query['ands'][0]['input']['data']['metadata']
       filters = [{
         "annotation": {
@@ -3594,6 +3592,8 @@ class ApiClient(object):
         }
       }]
       image = query['ands'][1]['output']['input']['data']['image']
+    else:
+      image = query['ands'][0]['output']['input']['data']['image']
 
     searches = [{
       'query': {
@@ -3607,6 +3607,8 @@ class ApiClient(object):
         "filters": filters
       }
     }]
+
+    print('searches %s' % searches)
 
     # Similar image search and predictions
     d = {'pagination': pagination(page, per_page).dict(),

--- a/clarifai/rest/client.py
+++ b/clarifai/rest/client.py
@@ -3585,18 +3585,23 @@ class ApiClient(object):
 
     # extract old query request values
     filters = []
-    if (len(query['ands']) == 2):
-      metadata = query['ands'][0]['input']['data']['metadata']
-      filters = [{
-        "annotation": {
-          "data": {
-            "metadata": metadata
+    image = None
+
+    try:
+      if (len(query['ands']) == 2):
+        metadata = query['ands'][0]['input']['data']['metadata']
+        filters = [{
+          "annotation": {
+            "data": {
+              "metadata": metadata
+            }
           }
-        }
-      }]
-      image = query['ands'][1]['output']['input']['data']['image']
-    else:
-      image = query['ands'][0]['output']['input']['data']['image']
+        }]
+        image = query['ands'][1]['output']['input']['data']['image']
+      else:
+        image = query['ands'][0]['output']['input']['data']['image']
+    except Exception as e:
+      raise ValueError('Failed to parse image search query with value {} {}'.format(query, e))
 
     # the new endpoint expects this shape of the request data object
     searches = [{

--- a/clarifai/rest/client.py
+++ b/clarifai/rest/client.py
@@ -3585,17 +3585,17 @@ class ApiClient(object):
     image_url = None
     metadata = None
     if (len(query['ands']) == 1):
-      image_url = query['ands'][0]['output']['input']['data']['image']['url']
+      image = query['ands'][0]['output']['input']['data']['image']
     else:
       metadata = query['ands'][0]['input']['data']['metadata']
-      image_url = query['ands'][1]['output']['input']['data']['image']['url']
+      image = query['ands'][1]['output']['input']['data']['image']
 
     searches = [{
       'query': {
         'ranks': [{
           'annotation': {
             "data": {
-              "image": image_url
+              "image": image
             }
           }
         }]


### PR DESCRIPTION
Update clarifai image search endpoint to the new version that fixes the problem of the reduced number of results per page. what I did here is changing the search endpoint, and mapping the existing request to the shape that this new endpoint expects.

This upgrade will also refine the result images (more accurate matching)

### Before
The deprecated endpoint returns only 5 results per page due to internal issue in Clarifai backend and the issue is not going to be fixed, only way is to use the new endpoint.
<img width="800" alt="Screen Shot 2024-04-16 at 11 34 50 AM" src="https://github.com/Revfluence/clarifai-python/assets/6517308/27833ba6-0394-4502-a991-0fbe78c3d6d0">


### After
<img width="800" alt="Screen Shot 2024-04-17 at 10 46 52 PM" src="https://github.com/Revfluence/clarifai-python/assets/6517308/de0548a8-68c2-48c8-9c94-819904bfe354">
