### PR TITLE
fix clarifai prediction api

### DIFF
--- a/clarifai/rest/client.py
+++ b/clarifai/rest/client.py
@@ -2586,8 +2586,9 @@ class Model(object):
       self.model_name = item['name']
       self.created_at = item['created_at']
       self.app_id = item['app_id']
-      self.model_version = item['model_version']['id']
-      self.model_status_code = item['model_version']['status']['code']
+      if ('model_version' in item):
+        self.model_version = item['model_version']['id']
+        self.model_status_code = item['model_version']['status']['code']
 
       self.output_info = item.get('output_info', {})
       self.concepts = []
@@ -4165,10 +4166,20 @@ class ApiClient(object):
       if not isinstance(obj, (Image, Video)):
         raise UserError("Object at position %d is not a valid type of content to add. Must be Image or Video" % i)
 
-    data = {"inputs": [obj.dict() for obj in objs]}
+    data = {
+      "user_app_id": {
+        "user_id": "aspire",
+        "app_id": CLARIFAI_APP_ID
+      },
+      "model_id": model_id,
+      "inputs": [obj.dict() for obj in objs]
+    }
 
     if model_output_info is not None:
       data.update({'model': model_output_info.dict()})
+
+    if version_id is not None:
+      data.update({ 'version_id': version_id })
 
     res = self.post(resource, data)
     return res

--- a/clarifai/rest/client.py
+++ b/clarifai/rest/client.py
@@ -4175,9 +4175,6 @@ class ApiClient(object):
       "inputs": [obj.dict() for obj in objs]
     }
 
-    if model_output_info is not None:
-      data.update({'model': model_output_info.dict()})
-
     if version_id is not None:
       data.update({ 'version_id': version_id })
 


### PR DESCRIPTION
### Before
Key Error happening due to model_version now optional in clarifai, and comes empty for some models.
```sh
File "/opt/backend-server/venv/lib/python3.9/site-packages/clarifai/rest/client.py", line 2591, in __init__
    self.model_version = item['model_version']['id']
    │                    └ {'id': 'people-vehicle-detection-efficientdet-lite', 'name': 'person-vehicle-lite', 'created_at': '2021-05-19T10:01:03.302502Z',...
    └ <clarifai.rest.client.Model object at 0xffff7a66b370>
KeyError: 'model_version'
```

After fixing that, an error caused the request payload would show from clarifai, as the api input has changed
```sh
 >> RESPONSE(1721766228.4680583) {
  "status": {
    "code": 11102,
    "description": "Invalid request",
    "details": "Malformed or invalid request"
  }
}
```

### After
after fixing both issues, I got a successful request from prediction api
```sh
{
  'status':{'code': 10000, 'description': 'Ok', 'req_id': '6f34adae8d104755a3f327d9e809eefb'}, 'outputs': [
    {
      'id': '11d26cdc4049487d923126f888f04377',
      'status': {'code': 10000, 'description': 'Ok'},
      'created_at': '2024-07-23T20:28:30.993610139Z',
      'model': {
        'id': 'general-image-recognition',
        'name': 'Image Recognition',
        'created_at': '2016-03-09T17:11:39.608845Z',
        'modified_at': '2023-12-18T08:54:35.172716Z',
        'app_id': 'main',
        'model_version': {
          'id': 'aa7f35c01e0642fda5cf400f543e7c40',
          'created_at': '2018-03-06T21:10:24.454834Z',
          'status': {'code': 21100,
          'description': 'Model is trained and ready for deployment'
          },
          'visibility': {'gettable': 50},
          'app_id': 'main',
          'user_id': 'clarifai',
          'metadata': {}},
          'user_id': 'clarifai',
          'model_type_id':
          'visual-classifier',
          'visibility': {'gettable': 50},
          'toolkits': [],
          'use_cases': [],
          'languages': [],
          'languages_full': [],
          'check_consents': [],
          'workflow_recommended': False,
          'image': {
            'url': 'https://s3.amazonaws.com/clarifai-api/img3/prod/large/8a8a5314ae1f4311b369f8a9527a697f/00ba04ce6efa93784f4473a96d5ee9b0',
            'hosted': {
              'prefix': 'https://s3.amazonaws.com/clarifai-api/img3/prod',
              'suffix': '8a8a5314ae1f4311b369f8a9527a697f/00ba04ce6efa93784f4473a96d5ee9b0', 'sizes': ['small', 'large']
            }
          }
        },
        'input': {
          'id': '817103494ad841f7852d7ec60ad99652',
          'data': {
            'image': {
              'url': 'https://storage.googleapis.com/aspirex-localhost-social-discovery-app/temp/SVktAdVDNrTkAP3gv5cHI1sdBt0YxV5M/influencer-image-search/c20a38a8-3928-41cd-92da-0864b2f745b2/c20a38a8-3928-41cd-92da-0864b2f745b2',
              'base64': 'dHJ1ZQ=='
            }
          }
        },
        'data': {
          'concepts': [
            {'id': 'ai_pCnxWJZh', 'name': 'contemporary', 'value': 0.9962529, 'app_id': 'main'},
            {'id': 'ai_X8N92R0N', 'name': 'faucet', 'value': 0.9955369, 'app_id': 'main'},
            {'id': 'ai_j09mzT6j', 'name': 'family', 'value': 0.9945162, 'app_id': 'main'},
            {'id': 'ai_c9n7SB25', 'name': 'furniture', 'value': 0.9941817, 'app_id': 'main'}, {'id': 'ai_Pf2b7clG', 'name': 'indoors', 'value': 0.99385864, 'app_id': 'main'},
            {'id': 'ai_lWJnj5XV', 'name': 'interior design', 'value': 0.9936526, 'app_id': 'main'}, {'id': 'ai_gCtlSsl1', 'name': 'bathroom', 'value': 0.9930455, 'app_id': 'main'},
            {'id': 'ai_pPxqdnP5', 'name': 'room', 'value': 0.9845835, 'app_id': 'main'},
            {'id': 'ai_zFnPQdgB', 'name': 'wood', 'value': 0.9840135, 'app_id': 'main'},
            {'id': 'ai_786Zr311', 'name': 'no person', 'value': 0.97969913, 'app_id': 'main'}, {'id': 'ai_D5KjgBR3', 'name': 'mirror', 'value': 0.9782496, 'app_id': 'main'},
            {'id': 'ai_9Dcdh0PK', 'name': 'house', 'value': 0.9744014, 'app_id': 'main'},
            {'id': 'ai_jqbMlN2c', 'name': 'hotel', 'value': 0.9726169, 'app_id': 'main'},
            {'id': 'ai_8LWlDfFD', 'name': 'table', 'value': 0.96031404, 'app_id': 'main'},
            {'id': 'ai_7Xg5SQRW', 'name': 'luxury', 'value': 0.95984626, 'app_id': 'main'},
            {'id': 'ai_VTlCx2f2', 'name': 'window', 'value': 0.95708674, 'app_id': 'main'},
            {'id': 'ai_xxnGcd42', 'name': 'seat', 'value': 0.9562494, 'app_id': 'main'},
            {'id': 'ai_3FsqkR4F', 'name': 'minimalist', 'value': 0.94711703, 'app_id': 'main'}, {'id': 'ai_7fhDkL1r', 'name': 'bathtub', 'value': 0.94566005, 'app_id': 'main'},
            {'id': 'ai_BJP7PBvG', 'name': 'apartment', 'value': 0.94090664, 'app_id': 'main'}]
      }
    }
]}
```