### PR TITLE
EPD-3028: Clarifai Python 3.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-future>=0.15, <2
-requests>=2.13, <3
-configparser>=3.5, <4
-jsonschema>=2.5, <3
-enum34>=1.1, <2
+future>=1.0.0, <2
+requests>=2.32.5, <3
+configparser>=3.8.1, <4
+jsonschema>=2.6, <3
+enum34>=1.1.10, <2

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,8 +1,8 @@
-nose>=1.3
-nose-timer>=0.7
-coverage>=3.7
-nosexcover>=1.0
-ndg-httpsclient>=0.4
-mock>=2.0
-requests>=2.13
-responses>=0.5
+nose>=1.3.7
+nose-timer>=1.0.1
+coverage>=7.11.0
+nosexcover>=1.0.11
+ndg-httpsclient>=0.5.1
+mock>=5.2.0
+requests>=2.32.5, <3
+responses>=0.25.8


### PR DESCRIPTION
This is used in backend & that is running python:3.10.18-bullseye

I wrote a dockerfile that is also using `python:3.10.18-bullseye`, pip install the requirements, and then pip freeze to know what version is being met. Updated the requirements to be the minimum of that for scanning.

  <details>
      <summary>The App+Test requirment.txt from Python:310.18-bullseye</summary>

===== APP REQUIREMENTS =====                                                                                                                                                                            
certifi==2025.10.5                                                                                                                                                                                      
charset-normalizer==3.4.4
configparser==3.8.1
enum34==1.1.10
future==1.0.0
idna==3.11
jsonschema==2.6.0
requests==2.32.5
urllib3==2.5.0

===== TEST REQUIREMENTS =====
certifi==2025.10.5
cffi==2.0.0
charset-normalizer==3.4.4
configparser==3.8.1
coverage==7.11.0
cryptography==46.0.3
enum34==1.1.10
future==1.0.0
idna==3.11
jsonschema==2.6.0
mock==5.2.0
ndg-httpsclient==0.5.1
nose==1.3.7
nose-timer==1.0.1
nosexcover==1.0.11
pyasn1==0.6.1
pycparser==2.23
pyOpenSSL==25.3.0
PyYAML==6.0.3
requests==2.32.5
responses==0.25.8
typing_extensions==4.15.0
urllib3==2.5.0
    </details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated all project dependencies to newer versions for improved stability and security. Core packages and testing utilities have been refreshed to their latest stable releases. All upper-bound version constraints remain unchanged to maintain backward compatibility and ensure a smooth upgrade experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->